### PR TITLE
Add support for .net 4.8

### DIFF
--- a/Source/WpfExceptionMessageBox/WpfExceptionMessageBox.csproj
+++ b/Source/WpfExceptionMessageBox/WpfExceptionMessageBox.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;netcoreapp3.1;net5.0-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <PackageTags>wpf exception messagebox</PackageTags>
     <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <ChangeLogFile>$(MSBuildProjectDirectory)/CHANGELOG.md</ChangeLogFile>


### PR DESCRIPTION
This would significantly ease the migration of existing applications using Microsoft.SqlServer.MessageBox since they currently only run on classic .NET Framework. 